### PR TITLE
Duo Mode default settings

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,36 @@
+- category: "security"
+  key: "headless_authorization_key"
+  keyFriendly: "Headless Endpoint Authorization Secret Key"
+  value: ""
+  admin: null
+  parsleyAccess: null
+  dataType: "text"
+  options: ""
+  tips: 'When a value is exists, requests to WebEngine gql, instant, and toJSON endpoints will require the header "Authorization: bearer [Secret Key]". Cache bust required to activate.'
+- category: "security"
+  key: "authorization_key"
+  keyFriendly: "Full WebEngine Authorization Secret Key"
+  value: ""
+  admin: null
+  parsleyAccess: null
+  dataType: "text"
+  options: ""
+  tips: 'When a value is exists, ALL requests to WebEngine will require the header "Authorization: bearer [Secret Key]" to resolve. Cache bust required to activate.'
+- category: "security"
+  key: "x_frame_options"
+  keyFriendly: "Header: X-Frame-Options"
+  value: ""
+  admin: null
+  parsleyAccess: null
+  dataType: "text"
+  options: "More info https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options"
+  tips: "Here are some suggestions"
+- category: "security"
+  key: "basic_content_api_key"
+  keyFriendly: "Basic Content API Key"
+  value: ""
+  admin: null
+  parsleyAccess: null
+  dataType: "text"
+  options: "More info https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options"
+  tips: "Here are some suggestions"

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,7 +1,7 @@
 - category: "security"
   key: "headless_authorization_key"
   keyFriendly: "Headless Endpoint Authorization Secret Key"
-  value: ""
+  value: null
   admin: null
   parsleyAccess: null
   dataType: "text"
@@ -10,7 +10,7 @@
 - category: "security"
   key: "authorization_key"
   keyFriendly: "Full WebEngine Authorization Secret Key"
-  value: ""
+  value: null
   admin: null
   parsleyAccess: null
   dataType: "text"
@@ -19,7 +19,7 @@
 - category: "security"
   key: "x_frame_options"
   keyFriendly: "Header: X-Frame-Options"
-  value: ""
+  value: null
   admin: null
   parsleyAccess: null
   dataType: "text"
@@ -28,7 +28,7 @@
 - category: "security"
   key: "basic_content_api_key"
   keyFriendly: "Basic Content API Key"
-  value: ""
+  value: null
   admin: null
   parsleyAccess: null
   dataType: "text"

--- a/zesty.module.json
+++ b/zesty.module.json
@@ -1,3 +1,4 @@
 {
-  "name": "Blank Template"
+  "name": "Blank Template",
+  "settings": "settings.yaml"
 }


### PR DESCRIPTION
enabling duo mode on starter template by updating the setting below to null.
basic_content_api_key
headless_authorization_key
authorization_key
x_frame_options

test template installation by accessing https://templating.api.zesty.io/ and specifying this branch on installation.
![image](https://github.com/zesty-io/template-simple-blog/assets/50983144/ae3bbc50-4535-43f2-a523-8ad05a0ef4ff)

